### PR TITLE
Fixed debian kernels support

### DIFF
--- a/scripts/vmware_wizard.py
+++ b/scripts/vmware_wizard.py
@@ -61,7 +61,7 @@ class VMwareWizard:
             
             # Parse version
             try:
-                version_parts = full_version.split('-')[0].split('.')
+                version_parts = full_version.split("-")[0].split("+")[0].split(".")
                 major = int(version_parts[0])
                 minor = int(version_parts[1]) if len(version_parts) > 1 else 0
                 patch = int(version_parts[2]) if len(version_parts) > 2 else 0


### PR DESCRIPTION
Debian kernel names use the format e.g. 6.17.13+deb14-amd64, which the script chokes on.